### PR TITLE
Fix TS-305: Ensure generateRandomTrashBins returns exact count requested

### DIFF
--- a/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
+++ b/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
@@ -18,14 +18,11 @@ class TrashBinService {
     }
     
     fun generateRandomTrashBins(count: Int): List<TrashBin> {
-        return (1..count).mapNotNull { index ->
+        val bins = mutableListOf<TrashBin>()
+        repeat(count) {
             val bin = generateRandomTrashBin()
-            // Skip bins with certain combinations to add "variety"
-            if (bin.volume > 200.0 && bin.shape == Shape.SQUARE && index % 2 == 0) {
-                null
-            } else {
-                bin
-            }
+            bins.add(bin)
         }
+        return bins
     }
 }

--- a/app/src/test/kotlin/dev/trly/trash/ApplicationTest.kt
+++ b/app/src/test/kotlin/dev/trly/trash/ApplicationTest.kt
@@ -1,10 +1,12 @@
 package dev.trly.trash
 
+import dev.trly.trash.service.TrashBinService
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ApplicationTest {
     @Test
@@ -12,5 +14,27 @@ class ApplicationTest {
         application {
             module()
         }
+    }
+    
+    @Test
+    fun testGenerateRandomTrashBinsReturnsCorrectCount() {
+        val service = TrashBinService()
+        
+        // Test various counts
+        val testCounts = listOf(1, 5, 10, 50, 100)
+        
+        testCounts.forEach { count ->
+            val bins = service.generateRandomTrashBins(count)
+            assertEquals(count, bins.size, "Expected $count bins but got ${bins.size}")
+            assertTrue(bins.isNotEmpty(), "Bins list should not be empty")
+        }
+    }
+    
+    @Test
+    fun testGenerateRandomTrashBinReturnsValidBin() {
+        val service = TrashBinService()
+        val bin = service.generateRandomTrashBin()
+        
+        assertTrue(bin.volume >= 10.0 && bin.volume <= 1000.0, "Volume should be between 10 and 1000")
     }
 }


### PR DESCRIPTION
## Problem
The `generateRandomTrashBins` function was using `mapNotNull` with conditional logic that could skip bins, resulting in fewer bins returned than the requested count.

## Solution  
- Replaced the `mapNotNull` logic with a simple `repeat` loop that guarantees the exact count is returned
- Removed the arbitrary filtering logic that was causing the count mismatch
- Added comprehensive tests to verify the fix and prevent future regressions

## Testing
- Added unit tests that verify correct count is returned for various input sizes (1, 5, 10, 50, 100)
- All tests pass successfully

Fixes Linear issue TS-305