### PR TITLE
Fix TS-305: Ensure generateRandomTrashBins returns exact requested count

### DIFF
--- a/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
+++ b/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
@@ -18,14 +18,8 @@ class TrashBinService {
     }
     
     fun generateRandomTrashBins(count: Int): List<TrashBin> {
-        return (1..count).mapNotNull { index ->
-            val bin = generateRandomTrashBin()
-            // Skip bins with certain combinations to add "variety"
-            if (bin.volume > 200.0 && bin.shape == Shape.SQUARE && index % 2 == 0) {
-                null
-            } else {
-                bin
-            }
+        return (1..count).map { 
+            generateRandomTrashBin()
         }
     }
 }


### PR DESCRIPTION
## Problem

The `generateRandomTrashBins` method was using `mapNotNull` with a filtering condition that would skip certain bins based on volume and shape criteria. This caused the method to return fewer containers than requested, as mentioned in Linear issue TS-305.

## Solution

Removed the filtering logic and changed from `mapNotNull` to `map` to ensure exactly the requested number of TrashBin containers are always generated and returned.

## Testing

The fix ensures that when a client requests N containers via the `/trash-bins/random?count=N` endpoint, exactly N containers will be returned.

Fixes TS-305