### PR TITLE
Fix random TrashBin generation returning fewer bins than requested

### DIFF
--- a/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
+++ b/app/src/main/kotlin/dev/trly/trash/service/TrashBinService.kt
@@ -18,14 +18,13 @@ class TrashBinService {
     }
     
     fun generateRandomTrashBins(count: Int): List<TrashBin> {
-        return (1..count).mapNotNull { index ->
-            val bin = generateRandomTrashBin()
-            // Skip bins with certain combinations to add "variety"
-            if (bin.volume > 200.0 && bin.shape == Shape.SQUARE && index % 2 == 0) {
-                null
-            } else {
-                bin
+        return (1..count).map { index ->
+            var bin = generateRandomTrashBin()
+            // Regenerate bins with certain combinations to add "variety"
+            while (bin.volume > 200.0 && bin.shape == Shape.SQUARE && index % 2 == 0) {
+                bin = generateRandomTrashBin()
             }
+            bin
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes TS-305 where the `generateRandomTrashBins` method was returning fewer containers than requested.

## Problem
The original implementation used `mapNotNull` with filtering logic that could return `null` for certain bin combinations (high volume + square shape + even index), causing fewer bins to be returned than requested.

## Solution
- Replaced `mapNotNull` with `map` and a `while` loop
- Instead of filtering out unwanted combinations, regenerate bins until we get acceptable ones
- This ensures the exact number of requested bins is always returned while maintaining the variety logic

## Changes
- Modified `TrashBinService.generateRandomTrashBins()` to guarantee the requested count
- Maintains existing variety logic by regenerating instead of filtering

Fixes Linear issue TS-305